### PR TITLE
Improve transit stop info

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,34 @@ body.dark-mode #zoomed-info-panel {
         border-color: rgba(255,255,255,0.2);
     }
 
+    .transit-label {
+        font-weight: bold;
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 0.85em;
+        margin-right: 4px;
+        border: 1px solid;
+    }
+    .transit-label.bus {
+        background-color: #d9534f; color: #fff; border-color: #b52b27;
+    }
+    .transit-label.rail {
+        background-color: #0275d8; color: #fff; border-color: #014c8c;
+    }
+    .transit-line {
+        font-weight: bold;
+        padding: 1px 4px;
+        border-radius: 3px;
+        margin-right: 4px;
+        background-color: #eee;
+        color: #222;
+        border: 1px solid #ccc;
+        font-size: 0.85em;
+    }
+    body.dark-mode .transit-line {
+        background-color: #555; color: #fff; border-color: #444;
+    }
+
     html, body {
     height: 100%; margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; 
     background-color: #f8f9fa; color: #212529;
@@ -3536,14 +3564,21 @@ function getVisibleListItemsDOM() {
             }
             try {
                 const { places } = await google.maps.places.Place.searchNearby({
-                    fields: ['displayName'],
+                    fields: ['displayName', 'types'],
                     locationRestriction: { center: new google.maps.LatLng(lat, lng), radius: 1200 },
                     includedPrimaryTypes: ['transit_station'],
-                    maxResultCount: 3,
+                    maxResultCount: 5,
                 });
                 if (!places || !places.length) return '';
                 let html = '<b>Nearby Transit Stops:</b><ul style="margin-top: 3px; margin-bottom: 3px; padding-left: 18px;">';
-                places.forEach(stop => { html += `<li>${stop.displayName}</li>`; });
+                places.forEach(stop => {
+                    const types = stop.types || [];
+                    const isBus = types.some(t => t.includes('bus'));
+                    const label = `<span class="transit-label ${isBus ? 'bus' : 'rail'}">${isBus ? 'Bus' : 'Rail'}</span>`;
+                    const lineMatch = stop.displayName && stop.displayName.match(/\(([^)]+)\)/);
+                    const line = lineMatch ? `<span class="transit-line">${lineMatch[1]}</span>` : '';
+                    html += `<li>${line}${label} ${stop.displayName}</li>`;
+                });
                 html += '</ul>';
                 return html;
             } catch (err) {


### PR DESCRIPTION
## Summary
- show up to five nearby transit stops
- label each stop as Bus or Rail with colored styling
- display line info when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68477bb4f8b8832aa971bda7b3d8fdaf